### PR TITLE
Update main menu and footer following changes made in October 2025

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,54 +3,30 @@
         <div class="global-footer__links">
             <div class="l-cluster">
                 <ul class="clean-list" role="list">
-                    <li>
-                        <a href="https://www.w3.org/" hreflang="en">
-                            <span lang="en" dir="ltr">Home</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://www.w3.org/contact/" hreflang="en">
-                            <span lang="en" dir="ltr">Contact</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://www.w3.org/help/" hreflang="en">
-                            <span lang="en" dir="ltr">Help</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://www.w3.org/donate/" hreflang="en">
-                            <span lang="en" dir="ltr">Donate</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://www.w3.org/policies/" hreflang="en">
-                            <span lang="en" dir="ltr">Legal &amp; Policies</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://www.w3.org/about/corporation/" hreflang="en">
-                            <span lang="en" dir="ltr">Corporation</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="https://status.w3.org/" hreflang="en">
-                            <span lang="en" dir="ltr">System Status</span>
-                        </a>
-                    </li>
+                        <li><a href="https://www.w3.org/" hreflang="en"><span lang="en" dir="ltr">Home</span></a></li>
+                        <li><a href="https://www.w3.org/contact/" hreflang="en"><span lang="en" dir="ltr">Contact</span></a></li>
+                        <li><a href="https://www.w3.org/help/" hreflang="en"><span lang="en" dir="ltr">Help</span></a></li>
+                        <li><a href="https://www.w3.org/support-us/" hreflang="en"><span lang="en" dir="ltr">Support us</span></a></li>
+                        <li><a href="https://www.w3.org/policies/" hreflang="en"><span lang="en" dir="ltr">Legal &amp; Policies</span></a></li>
+                        <li><a href="https://www.w3.org/about/corporation/" hreflang="en"><span lang="en" dir="ltr">Corporation</span></a></li>
+                        <li><a href="https://status.w3.org/" hreflang="en"><span lang="en" dir="ltr">System Status</span></a></li>
                 </ul>
             </div>
             <ul class="clean-list" role="list">
-                <li><a class="with-icon--larger" href="https://w3c.social/@w3c" hreflang="en">
-                        <img class="icon icon--larger" src="https://www.w3.org/assets/website-2021/svg/mastodon.svg" width="20" height="20" alt="" aria-hidden="true" loading="lazy">
-                        <span class="visuallyhidden"><span lang="en" dir="ltr">W3C on Mastodon</span></span></a>
+                <li>
+                    <a class="with-icon--larger" href="https://w3c.social/@w3c" hreflang="en">
+                        <img class="icon icon--larger" src="https://www.w3.org/assets/website-2021/svg/mastodon.svg" width="20" height="20" alt aria-hidden="true" loading="lazy"/>
+                        <span class="visuallyhidden"><span lang="en" dir="ltr">W3C on Mastodon</span></span>
+                    </a>
                 </li>
-                <li><a class="with-icon--larger" href="https://github.com/w3c/" hreflang="en">
-                        <img class="icon icon--larger" src="https://www.w3.org/assets/website-2021/svg/github.svg" width="20" height="20" alt="" aria-hidden="true" loading="lazy">
-                        <span class="visuallyhidden"><span lang="en" dir="ltr">W3C on GitHub</span></span></a>
+                <li>
+                    <a class="with-icon--larger" href="https://github.com/w3c/" hreflang="en">
+                        <img class="icon icon--larger" src="https://www.w3.org/assets/website-2021/svg/github.svg" width="20" height="20" alt aria-hidden="true" loading="lazy"/>
+                        <span class="visuallyhidden"><span lang="en" dir="ltr">W3C on GitHub</span></span>
+                    </a>
                 </li>
             </ul>
         </div>
-        <p class="copyright"><span lang="en" dir="ltr">Copyright © 2025 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br> <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#disclaimers">liability</a>, <a href="https://www.w3.org/policies/#trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/copyright/document-license/" title="W3C Document License">permissive license</a> rules apply.</span></p>
+        <p class="copyright"><span lang="en" dir="ltr">Copyright &copy; 2025 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br> <abbr title="World Wide Web Consortium">W3C</abbr><sup>&reg;</sup> <a href="https://www.w3.org/policies/#disclaimers">liability</a>, <a href="https://www.w3.org/policies/#trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/copyright/document-license/" title="W3C Document License">permissive license</a> rules apply.</span></p>
     </div>
 </footer>

--- a/_includes/header_with_menu.html
+++ b/_includes/header_with_menu.html
@@ -22,256 +22,158 @@
             <button type="button" class="button button--ghost with-icon--after with-icon--larger" data-trigger="mobile-nav"
                     style="display: none;"></button>
             <ul data-component="nav-double-intro">
-                                <li class="top-nav-item has-children">
-                        <a href="https://www.w3.org/standards/" class="nav-link">Standards</a>
+                    <li class="top-nav-item has-children">
+                        <a href="https://www.w3.org/standards/" class="nav-link">Standards &amp; groups</a>
                         <div class="nav__submenu" data-nav="submenu" style="display: none;">
                             <div class="l-center">
                                 <div class="nav__submenu__intro">
-                                    <h2 class="nav__submenu__intro__heading">Standards</h2>
+                                    <h2 class="nav__submenu__intro__heading">Standards &amp; groups</h2>
                                     <div class="nav__submenu__intro__text">
-                                                                                <p>Understand the various specifications, their maturity levels on the web standards track, and their adoption.</p>
-                                                                                                                    <a href="https://www.w3.org/standards/">Explore web standards</a>
-                                                                        </div>
+                                            <p>Understand the various specifications, their maturity levels on the web standards track, their adoption, and the groups that develop them.</p>
+                                            <a href="https://www.w3.org/standards/">Explore web standards</a>
+                                    </div>
                                 </div>
-                                                                <ul>
-                                                                                <li >
-                                                <a href="https://www.w3.org/standards/about/">About W3C web standards</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/TR/">W3C standards &amp; drafts</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/standards/types/">Types of documents W3C publishes</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/translations/">Translations of W3C standards &amp; drafts</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/standards/review/">Reviews &amp; public feedback</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/liaisons/">Liaisons</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/get-involved/promote/">Promote web standards</a>
-                                            </li>
-                                                                        </ul>
-                                                        </div>
+                                <ul>
+                                            <li><a href="https://www.w3.org/standards/about/">About W3C web standards</a></li>
+                                            <li><a href="https://www.w3.org/TR/">W3C standards &amp; drafts</a></li>
+                                            <li><a href="https://www.w3.org/standards/types/">Types of documents W3C publishes</a></li>
+                                            <li><a href="https://www.w3.org/groups/">W3C groups</a></li>
+                                            <li><a href="https://www.w3.org/translations/">Translations of W3C standards &amp; drafts</a></li>
+                                            <li><a href="https://www.w3.org/standards/review/">Reviews &amp; public feedback</a></li>
+                                            <li><a href="https://www.w3.org/get-involved/promote/">Promote web standards</a></li>
+                                            <li><a href="https://www.w3.org/liaisons/">Liaisons</a></li>
+                                            <li><a href="https://www.w3.org/groups/other/tag/">Technical Architecture Group (TAG)</a></li>
+                                    </ul>
+                            </div>
                         </div>
                     </li>
-                                <li class="top-nav-item has-children">
-                        <a href="https://www.w3.org/groups/" class="nav-link">Groups</a>
-                        <div class="nav__submenu" data-nav="submenu" style="display: none;">
-                            <div class="l-center">
-                                <div class="nav__submenu__intro">
-                                    <h2 class="nav__submenu__intro__heading">Groups</h2>
-                                    <div class="nav__submenu__intro__text">
-                                                                                <p>A variety of groups develop Web Standards, guidelines, or supporting materials.</p>
-                                                                                                                    <a href="https://www.w3.org/groups/">About W3C groups</a>
-                                                                        </div>
-                                </div>
-                                                                <ul>
-                                                                                <li >
-                                                <a href="https://www.w3.org/groups/wg/">Working Groups</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/groups/ig/">Interest Groups</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/groups/cg/">Community Groups</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/groups/bg/">Business Groups</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/groups/other/tag/">Technical Architecture Group</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/invited-experts/">Invited Experts</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/guide/">Participant guidebook</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/about/positive-work-environment/">Positive work environment</a>
-                                            </li>
-                                                                        </ul>
-                                                        </div>
-                        </div>
-                    </li>
-                                <li class="top-nav-item has-children">
+                    <li class="top-nav-item has-children">
                         <a href="https://www.w3.org/get-involved/" class="nav-link">Get involved</a>
                         <div class="nav__submenu" data-nav="submenu" style="display: none;">
                             <div class="l-center">
                                 <div class="nav__submenu__intro">
                                     <h2 class="nav__submenu__intro__heading">Get involved</h2>
                                     <div class="nav__submenu__intro__text">
-                                                                                <p>W3C works at the nexus of core technology, industry needs, and societal needs.</p>
-                                                                                                                    <a href="https://www.w3.org/get-involved/">Find ways to get involved</a>
-                                                                        </div>
+                                            <p>W3C works at the nexus of core technology, industry needs, and societal needs.</p>
+                                            <a href="https://www.w3.org/get-involved/">Find ways to get involved</a>
+                                    </div>
                                 </div>
-                                                                <ul>
-                                                                                <li >
-                                                <a href="https://www.w3.org/ecosystems/">Browse our work by industry</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/membership/">Become a Member</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/Member/">Member Home (restricted)</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/email/">Mailing lists</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/donate/">Make a donation</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/sponsor/">Sponsor an event</a>
-                                            </li>
-                                                                        </ul>
-                                                        </div>
+                                <ul>
+                                            <li><a href="https://www.w3.org/ecosystems/">Browse our work by industry</a></li>
+                                            <li><a href="https://www.w3.org/membership/">Become a Member</a></li>
+                                            <li><a href="https://www.w3.org/Member/">Member home (restricted)</a></li>
+                                            <li><a href="https://www.w3.org/support-us/">Support us</a></li>
+                                            <li><a href="https://www.w3.org/email/">Mailing lists</a></li>
+                                            <li><a href="https://www.w3.org/guide/">Participant guidebook</a></li>
+                                            <li><a href="https://www.w3.org/about/positive-work-environment/">Positive work environment</a></li>
+                                            <li><a href="https://www.w3.org/invited-experts/">Invited Experts</a></li>
+                                    </ul>
+                            </div>
                         </div>
                     </li>
-                                <li class="top-nav-item has-children">
+                    <li class="top-nav-item has-children">
                         <a href="https://www.w3.org/resources/" class="nav-link">Resources</a>
                         <div class="nav__submenu" data-nav="submenu" style="display: none;">
                             <div class="l-center">
                                 <div class="nav__submenu__intro">
                                     <h2 class="nav__submenu__intro__heading">Resources</h2>
                                     <div class="nav__submenu__intro__text">
-                                                                                <p>Master Web fundamentals, use our developer tools, or contribute code.</p>
-                                                                                                                    <a href="https://www.w3.org/resources/">Learn from W3C resources</a>
-                                                                        </div>
+                                            <p>Master web fundamentals, use our developer tools, or contribute code.</p>
+                                            <a href="https://www.w3.org/resources/">Learn from W3C resources</a>
+                                    </div>
                                 </div>
-                                                                <ul>
-                                                                                <li >
-                                                <a href="https://www.w3.org/developers/">Developers</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/developers/tools/">Validators &amp; tools</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/WAI/fundamentals/">Accessibility fundamentals</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/International/i18n-drafts/nav/about">Internationalization</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/translations/">Translations of W3C standards and drafts</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/policies/code-of-conduct/">Code of conduct</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/reports/">Reports</a>
-                                            </li>
-                                                                        </ul>
-                                                        </div>
+                                <ul>
+                                            <li><a href="https://www.w3.org/developers/">Developers</a></li>
+                                            <li><a href="https://www.w3.org/developers/tools/">Validators &amp; tools</a></li>
+                                            <li><a href="https://www.w3.org/WAI/fundamentals/">Accessibility fundamentals</a></li>
+                                            <li><a href="https://www.w3.org/International/i18n-drafts/nav/about">Internationalization (i18n)</a></li>
+                                            <li><a href="https://www.w3.org/translations/">Translations of W3C standards &amp; drafts</a></li>
+                                            <li><a href="https://www.w3.org/policies/code-of-conduct/">Code of conduct</a></li>
+                                            <li><a href="https://www.w3.org/reports/">Reports</a></li>
+                                    </ul>
+                            </div>
                         </div>
                     </li>
-                                <li class="top-nav-item has-children">
+                    <li class="top-nav-item has-children">
                         <a href="https://www.w3.org/news-events/" class="nav-link">News &amp; events</a>
                         <div class="nav__submenu" data-nav="submenu" style="display: none;">
                             <div class="l-center">
                                 <div class="nav__submenu__intro">
                                     <h2 class="nav__submenu__intro__heading">News &amp; events</h2>
                                     <div class="nav__submenu__intro__text">
-                                                                                <p>Recent content across news, blogs, press releases, media; upcoming events.</p>
-                                                                                                                    <a href="https://www.w3.org/news-events/">Follow news &amp; events</a>
-                                                                        </div>
+                                            <p>Recent content across news, blogs, press releases, media; upcoming events.</p>
+                                            <a href="https://www.w3.org/news-events/">Explore news &amp; events</a>
+                                    </div>
                                 </div>
-                                                                <ul>
-                                                                                <li >
-                                                <a href="https://www.w3.org/news/">News</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/blog/">Blog</a>
-                                            </li>
-                                                                                <li class="break-after">
-                                                <a href="https://www.w3.org/press-releases/">Press releases</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/about/press-media/">Press &amp; media</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/events/">Events</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/news-events/w3c-tpac/">Annual W3C Conference (TPAC)</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/policies/code-of-conduct/">Code of conduct</a>
-                                            </li>
-                                                                        </ul>
-                                                        </div>
+                                <ul>
+                                            <li><a href="https://www.w3.org/news/">News</a></li>
+                                            <li><a href="https://www.w3.org/blog/">Blog</a></li>
+                                            <li class="break-after"><a href="https://www.w3.org/press-releases/">Press releases</a></li>
+                                            <li><a href="https://www.w3.org/about/press-media/">Press &amp; media</a></li>
+                                            <li><a href="https://www.w3.org/events/">Events</a></li>
+                                            <li><a href="https://www.w3.org/news-events/w3c-tpac/">Annual W3C Conference (TPAC)</a></li>
+                                            <li><a href="https://www.w3.org/policies/code-of-conduct/">Code of conduct</a></li>
+                                    </ul>
+                            </div>
                         </div>
                     </li>
-                                <li class="top-nav-item has-children">
+                    <li class="top-nav-item has-children">
+                        <a href="https://www.w3.org/support-us/" class="nav-link">Support us</a>
+                        <div class="nav__submenu" data-nav="submenu" style="display: none;">
+                            <div class="l-center">
+                                <div class="nav__submenu__intro">
+                                    <h2 class="nav__submenu__intro__heading">Support us</h2>
+                                    <div class="nav__submenu__intro__text">
+                                            <p>Make a huge difference to our operations as a public-interest non-profit, and help us to achieve our vision.</p>
+                                            <a href=""></a>
+                                    </div>
+                                </div>
+                                <ul>
+                                            <li><a href="https://www.w3.org/support-us/">Ways you can support us</a></li>
+                                    </ul>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="top-nav-item has-children">
                         <a href="https://www.w3.org/about/" class="nav-link">About</a>
                         <div class="nav__submenu" data-nav="submenu" style="display: none;">
                             <div class="l-center">
                                 <div class="nav__submenu__intro">
                                     <h2 class="nav__submenu__intro__heading">About</h2>
                                     <div class="nav__submenu__intro__text">
-                                                                                <p>Understand our values and principles, learn our history, look into our policies, meet our people.</p>
-                                                                                                                    <a href="https://www.w3.org/about/">Find out more about us</a>
-                                                                        </div>
+                                            <p>Understand our values and principles, learn our history, look into our policies, meet our people.</p>
+                                            <a href="https://www.w3.org/about/">Find out more about us</a>
+                                    </div>
                                 </div>
-                                                                <ul>
-                                                                                <li >
-                                                <a href="https://www.w3.org/mission/">Our mission</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/about/leadership/">Leadership</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/staff/">Staff</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/evangelists/">Evangelists</a>
-                                            </li>
-                                                                                <li class="break-after">
-                                                <a href="https://www.w3.org/careers/">Careers</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/about/diversity/">Diversity</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/about/corporation/">Corporation</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/sponsor/">Sponsoring W3C</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/about/press-media/">Media kit</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/contact/">Contact</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/policies/">Policies &amp; legal information</a>
-                                            </li>
-                                                                                <li >
-                                                <a href="https://www.w3.org/help/">Help</a>
-                                            </li>
-                                                                        </ul>
-                                                        </div>
+                                <ul>
+                                            <li><a href="https://www.w3.org/mission/">Our mission</a></li>
+                                            <li><a href="https://www.w3.org/support-us/">Support us</a></li>
+                                            <li><a href="https://www.w3.org/about/leadership/">Leadership</a></li>
+                                            <li><a href="https://www.w3.org/staff/">Staff</a></li>
+                                            <li class="break-after"><a href="https://www.w3.org/careers/">Careers</a></li>
+                                            <li><a href="https://www.w3.org/about/press-media/">Media kit</a></li>
+                                            <li><a href="https://www.w3.org/about/diversity/">Diversity</a></li>
+                                            <li><a href="https://www.w3.org/evangelists/">Evangelists</a></li>
+                                            <li><a href="https://www.w3.org/about/corporation/">Corporation</a></li>
+                                            <li><a href="https://www.w3.org/policies/">Policies &amp; legal information</a></li>
+                                            <li><a href="https://www.w3.org/contact/">Contact us</a></li>
+                                            <li><a href="https://www.w3.org/help/">Help</a></li>
+                                    </ul>
+                            </div>
                         </div>
                     </li>
-                            <li class="top-nav-item">
-                    <a hreflang="en" href="https://www.w3.org/help/search/" class="nav-link icon-link">
+                <li class="top-nav-item">
+                                                                                        <a hreflang="en" href="https://www.w3.org/help/search/" class="nav-link icon-link">
                         <img class="icon" src="https://www.w3.org/assets/website-2021/svg/search.svg" width="24" height="24" alt aria-hidden="true"><span class="hide-at-max-width">Search</span>
                     </a>
                 </li>
                 <li class="top-nav-item">
                     <a hreflang="en" href="https://www.w3.org/users/myprofile/" id="account-login-link" class="account-login icon-link with-icon--after">
-                        My account <span class="avatar avatar--small icon">
-                            <img src="https://www.w3.org/assets/website-2021/svg/avatar.svg" width="24" height="24" alt aria-hidden="true"/>
-                        </span>
+                        My account
+                        <span class="avatar avatar--small icon"><img src="https://www.w3.org/assets/website-2021/svg/avatar.svg" width="24" height="24" alt aria-hidden="true"/></span>
                     </a>
                 </li>
             </ul>
         </div>
-    </nav>    
+    </nav>
 </header>


### PR DESCRIPTION
Some menu items got reordered, and in the footer the "Donate" link was replaced by "Support us".
This PR syncs the markup from https://www.w3.org/_fragments/global-nav/ and https://www.w3.org/_fragments/footer/

Old menu:
<img width="1150" height="126" alt="image" src="https://github.com/user-attachments/assets/ce004073-b0d8-4b12-aa2c-379defcfa720" />

New menu:
<img width="1150" height="126" alt="image" src="https://github.com/user-attachments/assets/988a72a8-82e9-407a-b08e-1db74274c2fd" />